### PR TITLE
Add support for ListConsumerGroups for a topic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,3 +99,6 @@ workflows:
     - release:
         requires:
           - test
+        filters:
+          branches:
+            only: master

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ go install github.com/gojek/kat
 - [List Topics](#list-topics)
 - [Describe Topics](#describe-topics)
 - [Delete Topics](#delete-topics)
+- [List Consumer Groups for a topic](#list-consumer-groups-for-a-topic)
 - [Increase Replication Factor](#increase-replication-factor)
 - [Reassign Partitions](#reassign-partitions)
 - [Show Topic Configs](#show-topic-configs)
@@ -82,6 +83,12 @@ kat topic delete --broker-list <"broker1:9092,broker2:9092"> --last-write=<epoch
 * Delete the topics that are not modified since the last-write epoch time and do not match the topic-blacklist regex
 ```
 kat topic delete --broker-list <"broker1:9092,broker2:9092"> --last-write=<epoch time> --data-dir=<kafka logs directory>  --topic-blacklist=<*test*>
+```
+
+### List Consumer Groups for a Topic
+* Lists all the consumer groups that are subscribed to a given topic
+```
+kat consumergroup list -b <"broker1:9092,broker2:9092"> -t <topic-name>
 ```
 
 ### Increase Replication Factor

--- a/cmd/consumergroup.go
+++ b/cmd/consumergroup.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"github.com/gojek/kat/cmd/list"
+	"github.com/gojek/kat/logger"
+	"github.com/spf13/cobra"
+)
+
+var consumerGroupCmd = &cobra.Command{
+	Use:   "consumergroup",
+	Short: "Admin commands on consumergroups",
+}
+
+func init() {
+	consumerGroupCmd.PersistentFlags().StringP("broker-list", "b", "", "Comma separated list of broker ips")
+	consumerGroupCmd.PersistentFlags().StringP("topic", "t", "", "Specify topic")
+	if err := consumerGroupCmd.MarkPersistentFlagRequired("broker-list"); err != nil {
+		logger.Fatal(err)
+	}
+
+	consumerGroupCmd.AddCommand(list.ListConsumerGroupsCmd)
+}

--- a/cmd/consumergroup.go
+++ b/cmd/consumergroup.go
@@ -13,8 +13,12 @@ var consumerGroupCmd = &cobra.Command{
 
 func init() {
 	consumerGroupCmd.PersistentFlags().StringP("broker-list", "b", "", "Comma separated list of broker ips")
-	consumerGroupCmd.PersistentFlags().StringP("topic", "t", "", "Specify topic")
 	if err := consumerGroupCmd.MarkPersistentFlagRequired("broker-list"); err != nil {
+		logger.Fatal(err)
+	}
+
+	consumerGroupCmd.PersistentFlags().StringP("topic", "t", "", "Specify topic")
+	if err := consumerGroupCmd.MarkPersistentFlagRequired("topic"); err != nil {
 		logger.Fatal(err)
 	}
 

--- a/cmd/list/listconsumergroup.go
+++ b/cmd/list/listconsumergroup.go
@@ -1,0 +1,57 @@
+package list
+
+import (
+	"strings"
+
+	"github.com/gojek/kat/cmd/base"
+	"github.com/gojek/kat/logger"
+	"github.com/gojek/kat/pkg/client"
+	"github.com/spf13/cobra"
+)
+
+type consumerGroupAdmin struct {
+	saramaClient client.ConsumerLister
+}
+
+var ListConsumerGroupsCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Lists the consumer groups",
+	Run: func(command *cobra.Command, args []string) {
+		cobraUtil := base.NewCobraUtil(command)
+
+		addr := strings.Split(cobraUtil.GetStringArg("broker-list"), ",")
+
+		cgl := consumerGroupAdmin{
+			saramaClient: client.NewSaramaClient(addr),
+		}
+		cgl.ListGroups(cobraUtil.GetStringArg("topic"))
+	},
+}
+
+func init() {
+	ListConsumerGroupsCmd.PersistentFlags().StringP("broker-list", "b", "", "Comma separated list of broker ips")
+	ListConsumerGroupsCmd.PersistentFlags().StringP("topic", "t", "", "Specify topic")
+	if err := ListConsumerGroupsCmd.MarkPersistentFlagRequired("broker-list"); err != nil {
+		logger.Fatal(err)
+	}
+}
+
+func (c *consumerGroupAdmin) ListGroups(topic string) error {
+	consumerGroupsMap, err := c.saramaClient.ListConsumerGroups()
+	if err != nil {
+		return err
+	}
+
+	var consumerGroups []string
+
+	for consumerGroupID := range consumerGroupsMap {
+		consumerGroups = append(consumerGroups, consumerGroupID)
+	}
+
+	_, err = c.saramaClient.GetConsumerGroupsForTopic(consumerGroups, topic)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/list/listconsumergroup.go
+++ b/cmd/list/listconsumergroup.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/gojek/kat/cmd/base"
+	"github.com/gojek/kat/logger"
 	"github.com/gojek/kat/pkg/client"
 	"github.com/spf13/cobra"
 )
@@ -24,7 +25,10 @@ var ListConsumerGroupsCmd = &cobra.Command{
 		cgl := consumerGroupAdmin{
 			saramaClient: client.NewSaramaClient(addr),
 		}
-		cgl.ListGroups(cobraUtil.GetStringArg("topic"))
+		err := cgl.ListGroups(cobraUtil.GetStringArg("topic"))
+		if err != nil {
+			logger.Fatalf("Error while listing consumer groups for %v topic", err)
+		}
 	},
 }
 

--- a/cmd/list/listconsumergroup.go
+++ b/cmd/list/listconsumergroup.go
@@ -1,10 +1,10 @@
 package list
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/gojek/kat/cmd/base"
-	"github.com/gojek/kat/logger"
 	"github.com/gojek/kat/pkg/client"
 	"github.com/spf13/cobra"
 )
@@ -28,19 +28,20 @@ var ListConsumerGroupsCmd = &cobra.Command{
 	},
 }
 
-func init() {
-	ListConsumerGroupsCmd.PersistentFlags().StringP("broker-list", "b", "", "Comma separated list of broker ips")
-	ListConsumerGroupsCmd.PersistentFlags().StringP("topic", "t", "", "Specify topic")
-	if err := ListConsumerGroupsCmd.MarkPersistentFlagRequired("broker-list"); err != nil {
-		logger.Fatal(err)
-	}
-}
-
 func (c *consumerGroupAdmin) ListGroups(topic string) error {
 	consumerGroupsMap, err := c.saramaClient.ListConsumerGroups()
 	if err != nil {
 		return err
 	}
+
+	consumerGroupList := make([]string, len(consumerGroupsMap))
+	for group := range consumerGroupsMap {
+		consumerGroupList = append(consumerGroupList, group)
+	}
+
+	sort.Slice(consumerGroupList, func(i int, j int) bool {
+		return consumerGroupList[i] < consumerGroupList[j]
+	})
 
 	var consumerGroups []string
 

--- a/cmd/list/listconsumergroup_test.go
+++ b/cmd/list/listconsumergroup_test.go
@@ -1,0 +1,67 @@
+package list
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
+)
+
+type mockConsumerListener struct{ mock.Mock }
+
+func (m *mockConsumerListener) ListConsumerGroups() (map[string]string, error) {
+	args := m.Called()
+	return args.Get(0).(map[string]string), args.Error(1)
+}
+
+func (m *mockConsumerListener) GetConsumerGroupsForTopic(consumerGroups []string, topic string) (chan string, error) {
+	args := m.Called(consumerGroups, topic)
+	return args.Get(0).(chan string), args.Error(1)
+}
+
+func TestListGroupsReturnsSuccess(t *testing.T) {
+	mockConsumer := new(mockConsumerListener)
+	admin := consumerGroupAdmin{mockConsumer}
+	mockChannel := make(chan string, 0)
+
+	consumerGroupsMap := map[string]string{"consumer1": "", "consumer2": ""}
+	mockConsumer.On("ListConsumerGroups").Return(consumerGroupsMap, nil)
+
+	mockConsumer.On("GetConsumerGroupsForTopic", []string{"consumer1", "consumer2"}, "").Return(mockChannel, nil)
+
+	err := admin.ListGroups("")
+
+	require.NoError(t, err)
+	mockConsumer.AssertExpectations(t)
+}
+
+func TestListGroupsReturnsFailureIfListConsumerGroupsFails(t *testing.T) {
+	mockConsumer := new(mockConsumerListener)
+	admin := consumerGroupAdmin{mockConsumer}
+	multipleConsumers := map[string]string{"consumer1": "", "consumer2": ""}
+	mockConsumer.On("ListConsumerGroups").Return(multipleConsumers, errors.New("list consumer groups failed"))
+
+	err := admin.ListGroups("")
+
+	require.Error(t, err)
+	assert.Equal(t, "list consumer groups failed", err.Error())
+	mockConsumer.AssertExpectations(t)
+}
+
+func TestListGroupsReturnsFailureIfGetConsumerGroupsFails(t *testing.T) {
+	mockConsumer := new(mockConsumerListener)
+	admin := consumerGroupAdmin{mockConsumer}
+	mockChannel := make(chan string, 0)
+
+	consumerGroupsMap := map[string]string{"consumer1": "", "consumer2": ""}
+	mockConsumer.On("ListConsumerGroups").Return(consumerGroupsMap, nil)
+
+	mockConsumer.On("GetConsumerGroupsForTopic", []string{"consumer1", "consumer2"}, "").Return(mockChannel, errors.New("get consumer groups failed"))
+
+	err := admin.ListGroups("")
+	require.Error(t, err)
+	assert.Equal(t, "get consumer groups failed", err.Error())
+	mockConsumer.AssertExpectations(t)
+}

--- a/cmd/list/listconsumergroup_test.go
+++ b/cmd/list/listconsumergroup_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"gotest.tools/assert"
 )
 
 type mockConsumerListener struct{ mock.Mock }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/gojek/kat/cmd/list"
 	"github.com/gojek/kat/cmd/mirror"
 
 	"github.com/gojek/kat/logger"
@@ -20,6 +21,7 @@ func init() {
 	cobra.OnInitialize()
 	cliCmd.AddCommand(topicCmd)
 	cliCmd.AddCommand(mirror.MirrorCmd)
+	cliCmd.AddCommand(list.ListConsumerGroupsCmd)
 }
 
 func Execute() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/gojek/kat/cmd/list"
 	"github.com/gojek/kat/cmd/mirror"
 
 	"github.com/gojek/kat/logger"
@@ -21,7 +20,7 @@ func init() {
 	cobra.OnInitialize()
 	cliCmd.AddCommand(topicCmd)
 	cliCmd.AddCommand(mirror.MirrorCmd)
-	cliCmd.AddCommand(list.ListConsumerGroupsCmd)
+	cliCmd.AddCommand(consumerGroupCmd)
 }
 
 func Execute() {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.5 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.1
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/r3labs/diff v0.0.0-20191018104334-e3ae93f4edbb
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.3
@@ -19,4 +19,5 @@ require (
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf
 	golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271 // indirect
+	gotest.tools v2.2.0+incompatible
 )

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.5 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.1
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/r3labs/diff v0.0.0-20191018104334-e3ae93f4edbb
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.3

--- a/go.mod
+++ b/go.mod
@@ -19,5 +19,4 @@ require (
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf
 	golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271 // indirect
-	gotest.tools v2.2.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/olekukonko/tablewriter v0.0.1 h1:b3iUnf1v+ppJiOfNX4yxxqfWKMQPZR5yoh8u
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/pierrec/lz4 v2.2.6+incompatible h1:6aCX4/YZ9v8q69hTyiR7dNLnTA3fgtKHVVW5BCd5Znw=
 github.com/pierrec/lz4 v2.2.6+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/r3labs/diff v0.0.0-20191018104334-e3ae93f4edbb h1:kaV32NbiIn7ESdHB4PEW2VTKhB0odk9wo4/yW2acmoo=
@@ -95,3 +97,5 @@ gopkg.in/jcmturner/gokrb5.v7 v7.2.3 h1:hHMV/yKPwMnJhPuPx7pH2Uw/3Qyf+thJYlisUc440
 gopkg.in/jcmturner/gokrb5.v7 v7.2.3/go.mod h1:l8VISx+WGYp+Fp7KRbsiUuXTTOnxIc3Tuvyavf11/WM=
 gopkg.in/jcmturner/rpc.v1 v1.1.0 h1:QHIUxTX1ISuAv9dD2wJ9HWQVuWDX/Zc0PfeC2tjc4rU=
 gopkg.in/jcmturner/rpc.v1 v1.1.0/go.mod h1:YIdkC4XfD6GXbzje11McwsDuOlZQSb9W4vfLvuNnlv8=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=

--- a/go.sum
+++ b/go.sum
@@ -97,5 +97,3 @@ gopkg.in/jcmturner/gokrb5.v7 v7.2.3 h1:hHMV/yKPwMnJhPuPx7pH2Uw/3Qyf+thJYlisUc440
 gopkg.in/jcmturner/gokrb5.v7 v7.2.3/go.mod h1:l8VISx+WGYp+Fp7KRbsiUuXTTOnxIc3Tuvyavf11/WM=
 gopkg.in/jcmturner/rpc.v1 v1.1.0 h1:QHIUxTX1ISuAv9dD2wJ9HWQVuWDX/Zc0PfeC2tjc4rU=
 gopkg.in/jcmturner/rpc.v1 v1.1.0/go.mod h1:YIdkC4XfD6GXbzje11McwsDuOlZQSb9W4vfLvuNnlv8=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
-gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=

--- a/pkg/client/consumerlister.go
+++ b/pkg/client/consumerlister.go
@@ -1,0 +1,6 @@
+package client
+
+type ConsumerLister interface {
+	ListConsumerGroups() (map[string]string, error)
+	GetConsumerGroupsForTopic([]string, string) (chan string, error)
+}

--- a/pkg/client/saramaclient.go
+++ b/pkg/client/saramaclient.go
@@ -80,6 +80,17 @@ func (s *SaramaClient) GetConsumerGroupsForTopic(groups []string, topic string) 
 			groupDescription, _ := s.admin.DescribeConsumerGroups([]string{groups[i]})
 			for _, memberDesc := range groupDescription[0].Members {
 				ma, _ := memberDesc.GetMemberAssignment()
+				fmt.Println("----version----")
+				fmt.Println(ma.Version)
+				fmt.Println("----version----")
+
+				fmt.Println("----userdata----")
+				fmt.Println(ma.UserData)
+				fmt.Println("----userdata----")
+
+				fmt.Println("----topics----")
+				fmt.Println(ma.Topics)
+				fmt.Println("----topics----")
 				for topicName, _ := range ma.Topics {
 					if topicName == topic {
 						consumerGroupsChannel <- groupDescription[0].GroupId

--- a/pkg/client/saramaclient_test.go
+++ b/pkg/client/saramaclient_test.go
@@ -296,8 +296,7 @@ func TestSaramaClient_GetConsumerGroupsForTopic(t *testing.T) {
 
 	admin.On("DescribeConsumerGroups", []string{"test-group-id"}).Return(groupDesciption, nil)
 
-	consumerGroupChannel, err := client.GetConsumerGroupsForTopic([]string{"test-group-id"}, "test-topic")
+	_, err := client.GetConsumerGroupsForTopic([]string{"test-group-id"}, "test-topic")
 
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(consumerGroupChannel))
 }


### PR DESCRIPTION
The PR adds support for listing all consumer groups for a given topic, feature requested through #7. 

Adds unit tests as well.

Co-authored-by: ys-achinta <ys.achinta@go-pay.co.id>